### PR TITLE
Pass modal props between components

### DIFF
--- a/ARPorts.tsx
+++ b/ARPorts.tsx
@@ -23,7 +23,7 @@ import CustomisableAlert from 'react-native-customisable-alert'
 type ActivateModal = 'UP' | 'DOWN'
 
 // { port }: { port?: Port }
-const poortGraph = () => {
+const PoortGraph = ({ openModal }) => {
   const [evenPortList, setEvenPortList] = useState<Port[] | undefined>([])
   const [oddPortList, setOddPortList] = useState<Port[] | undefined>([])
   const [modalVisible, setModalVisible] = useState(false)
@@ -32,6 +32,7 @@ const poortGraph = () => {
 
   const showModal = (pn) => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+    openModal()
   }
 
   ViroARTrackingTargets.createTargets({
@@ -159,15 +160,15 @@ const poortGraph = () => {
 }
 
 export default () => {
-  const [showModal, setShowModal] = useState<ActivateModal | undefined>()
+  const [modalVisible, setModalVisible] = useState(false)
   return (
     <>
       <ViroARSceneNavigator
         shadowsEnabled={true}
         autofocus={true}
-        initialScene={{ scene: poortGraph }}
+        initialScene={{ scene: <PoortGraph openModal={() => setModalVisible(true)} /> }}
       />
-      {showModal === 'UP' && <PortModal />}
+      <PortModal visible={modalVisible} hideModal={() => setModalVisible(false)} />
       <ProfileBtn />
     </>
   )

--- a/PortModal.tsx
+++ b/PortModal.tsx
@@ -21,27 +21,25 @@ import color from '../styles/color'
 import Port from '../interfaces/Port'
 import core from '../styles/core'
 
-const PortModal = ({ visible }: { visible?: boolean }) => {
+const PortModal = ({ visible, hideModal }: { visible?: boolean, hideModal: () => void }) => {
   // { port }: { port?: Port }
 
-  const [modalVisible, setModalVisible] = useState(true)
-  if (visible !== undefined) setModalVisible(visible)
   return (
     <View style={styles.centeredView}>
       <Modal
         animationType="slide"
         transparent={true}
-        visible={modalVisible}
+        visible={visible}
         onRequestClose={() => {
           // Alert.alert('Modal has been closed.')
-          setModalVisible(!modalVisible)
+          hideModal()
         }}
       >
         <View style={styles.centeredView}>
           <View style={styles.modalView}>
             <Pressable
               style={[styles.button, styles.buttonClose]}
-              onPress={() => setModalVisible(!modalVisible)}
+              onPress={hideModal}
             >
               <FontAwesome name="close" size={28} color="black" />
             </Pressable>


### PR DESCRIPTION
In dit voorbeeld maak ik één component de baas over de state (je parent component). Vanaf daar geef ik de state (en setter functions) letterlijk door naar children (de modal en de ARView) waar nodig. 

Enige kanttekening: ik kan in de Viro documentatie niet vinden hoe het de bedoeling is dat je properties meegeeft aan de `initialScene` van de Navigator. In mijn voorbeeld doe ik dat door het hele JSX component met properties en al mee te geven. Volgens de documentatie mag dat, maar ik heb het niet kunnen testen.